### PR TITLE
migrate to null safety

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.4.0
+  - 2.12.0
 
 dart_task:
   - test: --platform vm,chrome,firefox

--- a/lib/euc.dart
+++ b/lib/euc.dart
@@ -39,7 +39,7 @@ class EucJPEncoder extends Converter<String, List<int>> {
       var value = 0;
 
       for (var i = 0, length = bytes.length; i < length; i++) {
-        value += bytes[i] * pow(256, (bytes.length - i - 1));
+        value += bytes[i] * (pow(256, (bytes.length - i - 1)) as int);
       }
 
       result.addAll(UTF_TABLE[value] ?? []);

--- a/lib/jis.dart
+++ b/lib/jis.dart
@@ -40,7 +40,7 @@ class JISEncoder extends Converter<String, List<int>> {
       var value = 0;
 
       for (var i = 0, length = bytes.length; i < length; i++) {
-        value += bytes[i] * pow(256, (bytes.length - i - 1));
+        value += bytes[i] * (pow(256, (bytes.length - i - 1)) as int);
       }
 
       result.addAll(UTF_TABLE[value] ?? []);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ homepage: https://github.com/dsh0416/euc-jp
 version: 1.0.5+7
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
 


### PR DESCRIPTION
I created a patch to support null-safety.
Since null-safety support requires version 2.12.0 or higher, I changed the dart version in pubspec.yaml and travis.yaml.